### PR TITLE
Fix: Show correct npm version badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A CLI tool to detect and uninstall unused npm dependencies from your Node.js pro
 
 ## Status
 
-[![npm version](https://badge.fury.io/js/npm-uninstall-unused.svg)](https://badge.fury.io/js/npm-uninstall-unused)
+[![npm version](https://img.shields.io/npm/v/npm-uninstall-unused.svg)](https://www.npmjs.com/package/npm-uninstall-unused)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Why use this?


### PR DESCRIPTION
### What’s Changed

- Updated the npm version badge in the README to correctly display the published version from npmjs.com.
- This makes it easier for users to see the latest version directly from the repo.

### Why

- The previous badge was showing "not found" due to an incorrect or outdated badge URL.
- This fix ensures the badge always reflects the current published version.